### PR TITLE
Add Typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![MELPA Stable](https://stable.melpa.org/packages/lsp-sonarlint-badge.svg)](https://stable.melpa.org/#/lsp-sonarlint)
 <a href="https://www.sonarlint.org/"> <img align="right" width="120" src="./images/SonarLint_icon.svg"></a>
 
-
-
 SonarLint™ is a free IDE extension that lets you fix coding issues before they exist!
 
 Like a spell checker,it highlights Bugs and Security Vulnerabilities as you write code, with clear remediation guidance so you can fix them before the code is even committed. 
@@ -64,7 +62,7 @@ the URL defined in **lsp-sonarlint-LANGUAGENAME-download-url**.
 
 
 #### Complete config example
-In this example, we have a multiple language project, with javascript,HTML and PHP:
+In this example, we have a multiple language project, with Javascript Typescript, HTML and PHP:
 
 ``` lisp
 (require 'lsp-sonarlint)
@@ -75,12 +73,14 @@ In this example, we have a multiple language project, with javascript,HTML and P
 (require 'lsp-sonarlint-html)
 (setq lsp-sonarlint-html-enabled t)
 
-
 (require 'lsp-sonarlint-javascript)
 (setq lsp-sonarlint-javascript-enabled t)
 
+(require 'lsp-sonarlint-typescript)
+(setq lsp-sonarlint-typescript-enabled t)
 ``` 
-Now we can active the lsp extension.
+
+Now we can activate the lsp extension.
 
 The extension will check every plugin path and ask if it is not find to download it,
 the default path is defined in **lsp-sonarlint-LANGUAGENAME-analyzer-path**.
@@ -118,8 +118,6 @@ This settigns are common for all the language plugins.
 * `lsp-sonarlint-LANGUAGE-doc-url` - Sonarsource official plugin documentation
 * `lsp-sonarlint-LANGUAGE-repository-url` - Plugin source code
 
-
-
 ## Data and telemetry
 
 This extension collects anonymous usage data and sends it to SonarSource. 
@@ -134,7 +132,6 @@ Click [here](https://github.com/SonarSource/sonarlint-vscode/blob/master/telemet
 * [company-capf](https://github.com/company-mode/company-mode) : Completion backend support.
 * [treemacs](https://github.com/Alexander-Miller/treemacs) : Project viewer.
 * [lsp-treemacs](https://github.com/emacs-lsp/lsp-treemacs) : `lsp-mode` GUI controls implemented using treemacs.
-
 
 ## Contributions
 

--- a/languages/javascript/lsp-sonarlint-javascript.el
+++ b/languages/javascript/lsp-sonarlint-javascript.el
@@ -28,7 +28,7 @@
 (defgroup lsp-sonarlint-javascript nil
   "lsp-sonarlint javascript analyzer group"
   :group 'lsp-sonarlint
-  :version '(lsp-sonarlint-javascript . "6.2.1"))
+  :version '(lsp-sonarlint-javascript . "8.2.0"))
 
 (defcustom lsp-sonarlint-javascript-enabled nil
   "Enable lsp-sonarlint-javascript plugin."
@@ -36,7 +36,7 @@
   :type 'boolean)
 
 (defcustom lsp-sonarlint-javascript-download-url
-  "https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-6.2.1.12157.jar"
+  "https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-8.2.0.16042.jar"
   "Javascript plugin download URL."
   :group 'lsp-sonarlint-javascript
   :type 'string)

--- a/languages/ruby/lsp-sonarlint-ruby.el
+++ b/languages/ruby/lsp-sonarlint-ruby.el
@@ -28,7 +28,7 @@
 (defgroup lsp-sonarlint-ruby nil
   "lsp-sonarlint ruby analyzer group"
   :group 'lsp-sonarlint
-  :version '(lsp-sonarlint-ruby . "1.7.0"))
+  :version '(lsp-sonarlint-ruby . "1.8.3"))
 
 (defcustom lsp-sonarlint-ruby-enabled nil
   "Enable lsp-sonarlint-ruby plugin."
@@ -36,7 +36,7 @@
   :type 'boolean)
 
 (defcustom lsp-sonarlint-ruby-download-url
-  "https://binaries.sonarsource.com/Distribution/sonar-ruby-plugin/sonar-ruby-plugin-1.7.0.883.jar"
+  "https://binaries.sonarsource.com/Distribution/sonar-ruby-plugin/sonar-ruby-plugin-1.8.3.2219.jar"
   "Ruby plugin download URL."
   :group 'lsp-sonarlint-ruby
   :type 'string)

--- a/languages/typescript/lsp-sonarlint-typescript.el
+++ b/languages/typescript/lsp-sonarlint-typescript.el
@@ -1,0 +1,59 @@
+;;; lsp-sonarlint-typescript.el --- lsp-sonarlint typescript module  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021  Gueorgui Tcherednitchenko
+;; Author: Gueorgui Tcherednitchenko <gt@gueorgui.net>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Specific configuration for the sonarlint typescript plugin.
+
+;; This is NOT and official Sonarlint extension.
+
+
+;;; Code:
+
+(defgroup lsp-sonarlint-typescript nil
+  "lsp-sonarlint typescript analyzer group"
+  :group 'lsp-sonarlint
+  :version '(lsp-sonarlint-typescript . "8.2.0"))
+
+(defcustom lsp-sonarlint-typescript-enabled nil
+  "Enable lsp-sonarlint-typescript plugin."
+  :group 'lsp-sonarlint-typescript
+  :type 'boolean)
+
+(defcustom lsp-sonarlint-typescript-download-url
+  "https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-8.2.0.16042.jar"
+  "Typescript plugin download URL."
+  :group 'lsp-sonarlint-typescript
+  :type 'string)
+
+(defcustom lsp-sonarlint-typescript-analyzer-path
+(concat
+   (file-name-directory load-file-name)
+   "sonar-typescript.jar")
+  "Lsp-sonarlint typescript analyzer location."
+  :group 'lsp-sonarlint-typescript
+  :type 'file)
+
+(defvar lsp-sonarlint-typescript-doc-url "https://www.sonarsource.com/ts/"
+  "Documentation sonarsource URL.")
+
+(defvar lsp-sonarlint-typescript-repository-url "https://github.com/SonarSource/SonarJS"
+  "Official sonarlint code extension reposiroty.")
+
+(provide 'lsp-sonarlint-typescript)
+;;; lsp-sonarlint-typescript.el ends here

--- a/lsp-sonarlint.el
+++ b/lsp-sonarlint.el
@@ -52,7 +52,19 @@
   :group 'lsp-sonarlint
   :type 'file)
 
-(defcustom lsp-sonarlint-modes-enabled '(php-mode html-mode web-mode js-mode js2-mode python-mode java-mode ruby-mode scala-mode xml-mode nxml-mode)
+(defcustom lsp-sonarlint-modes-enabled '(php-mode
+                                         html-mode
+                                         web-mode
+                                         js-mode
+                                         js2-mode
+                                         rjsx-mode
+                                         typescript-mode
+                                         typescript-tsx-mode
+                                         python-mode java-mode
+                                         ruby-mode
+                                         scala-mode
+                                         xml-mode
+                                         nxml-mode)
   "List of enabled major modes."
   :group 'lsp-sonarlint
   :type 'file)


### PR DESCRIPTION
This pull request adds Typescript support, as mentioned in #7.

I've also updated the documentation, and updated a couple of other Sonarlint plugins to the latest versions (Javascript, Ruby).

This is my first time making a pull request with Elisp and my first time working on an Emacs package, please let me know if there is anything that I have missed or that could be done better.