### PR TITLE
Allow connecting to a remote Sonarqube instance

### DIFF
--- a/lsp-sonarlint.el
+++ b/lsp-sonarlint.el
@@ -83,11 +83,34 @@ Example: `{**/test/**,**/*test*,**/*Test*}`"
   :group 'lsp-sonarlint
   :type 'string)
 
-(defcustom lsp-sonarlint-sonarqube-server-url ""
-  "URL of the server.
-e.g https://<myServerUrl>"
+(defcustom lsp-sonarlint-connections-sonarqube []
+  "Connections to sonarqube instances.
+
+Ex:
+\(setq lsp-sonarlint-connections-sonarqube '[((serverUrl . \"https://...\") (token . \"my-token\"))]\)"
   :group 'lsp-sonarlint
-  :type 'string)
+  :type '(vector (alist :key-type symbol :value-type string)))
+
+(defcustom lsp-sonarlint-connections-sonarcloud []
+  "Connections to sonarcloud instances.
+
+Ex:
+\(setq lsp-sonarlint-connections-sonarqube '[((connectionId . \"my-connection\") (organizationKey . \"my-organization-key\") (token . \"my-token\"))]\)"
+  :group 'lsp-sonarlint
+  :type '(vector (alist :key-type symbol :value-type string)))
+
+(defcustom lsp-sonarlint-servers []
+  ""
+  :group 'lsp-sonarlint
+  :type '(vector (alist :key-type symbol :value-type string)))
+
+(defcustom lsp-sonarlint-project '()
+  "Sonar project configuration.
+
+Ex:
+\(setq lsp-sonarlint-project '((projectKey . \"my-project\"))\)"
+  :group 'lsp-sonarlint
+  :type '(alist :key-type symbol :value-type string))
 
 (defcustom lsp-sonarlint-show-analyzer-logs nil
   "Show analyzer's logs in the SonarLint output."
@@ -163,7 +186,11 @@ analyzer"
  '(("sonarlint.disableTelemetry" lsp-sonarlint-disable-telemetry)
    ("sonarlint.testFilePattern" lsp-sonarlint-test-file-pattern)
    ("sonarlint.output.showAnalyzerLogs" lsp-sonarlint-show-analyzer-logs)
-   ("sonarlint.ls.vmargs" lsp-sonarlint-vmargs)))
+   ("sonarlint.ls.vmargs" lsp-sonarlint-vmargs)
+   ("sonarlint.connectedMode.servers" lsp-sonarlint-servers)
+   ("sonarlint.connectedMode.connections.sonarqube" lsp-sonarlint-connections-sonarqube)
+   ("sonarlint.connectedMode.connections.sonarcloud" lsp-sonarlint-connections-sonarcloud)
+   ("sonarlint.connectedMode.project" lsp-sonarlint-project)))
 
 (lsp-register-client
  (make-lsp-client


### PR DESCRIPTION
This is a WIP.

Missing:
- [ ] An actually working implementation !
- [ ] A README entry
- [x] The variable for sonarcloud

This PR adds the custom variables necessary, according to the VSCode extension documentation, to connect sonarlint to a remote Sonarqube instance. However, I can't get it to actually display the issues raised by my sonarqube instance.

The variables in this PR should be used this way if I understand correctly:

```lisp
  (setq lsp-sonarlint-connections-sonarqube '[((serverUrl . "https://...")
						    (token . "..."))]
	      lsp-sonarlint-project '((projectKey . "...")))
```

I configured lsp-sonarling with my sonarqube instance, and did the same in parallel in VSCode. I enabled the language server I/O logs. I see that the params are sent to the language server, and it does it using the same structure than VSCode. So I'm not sure what's missing here... I still submit the PR in the hope someone has an idea about what I did wrong here... I will gladly close it if this was a bad idea.

Once this PR is finished and merged, this should fix #1 